### PR TITLE
Update to latest rust

### DIFF
--- a/src/mach.rs
+++ b/src/mach.rs
@@ -9,6 +9,7 @@ type AbsTime = u64;
 mod ffi {
   use libc::{c_int, mach_timebase_info};
 
+  #[allow(non_camel_case_types)]
   pub type kern_return_t = c_int;
   pub const KERN_SUCCESS: kern_return_t = 0;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,7 +63,7 @@ fn bench_1ms(b: &mut Bencher) {
 fn bench_100us_sum(b: &mut Bencher) {
   let mut snooze = Snooze::new(Duration::microseconds(100)).unwrap();
   b.iter(|| {
-    for _ in range_inclusive(0, 100us) {
+    for _ in range_inclusive(0, 100usize) {
       snooze.wait().unwrap()
     }
   });
@@ -72,7 +72,7 @@ fn bench_100us_sum(b: &mut Bencher) {
 fn bench_1ms_sum(b: &mut Bencher) {
   let mut snooze = Snooze::new(Duration::milliseconds(1)).unwrap();
   b.iter(|| {
-    for _ in range_inclusive(0, 10us) {
+    for _ in range_inclusive(0, 10usize) {
       snooze.wait().unwrap()
     }
   });

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,12 +15,16 @@ mod ffi {
   use libc::{BOOL, HANDLE, LARGE_INTEGER, LONG, LPSECURITY_ATTRIBUTES, LPVOID};
   use libc::types::os::arch::extra::{LPCWSTR};
 
+  #[allow(non_camel_case_types)]
   pub type LPCTSTR = LPCWSTR;
 
   extern "stdcall" {
+    #[allow(non_snake_case_functions)]
     pub fn CreateWaitableTimerW(lpTimerAttributes: LPSECURITY_ATTRIBUTES,
                                 bManualReset: BOOL,
                                 lpTimerName: LPCTSTR) -> HANDLE;
+
+    #[allow(non_snake_case_functions)]
     pub fn SetWaitableTimer(hTimer: HANDLE,
                             pDueTime: *const LARGE_INTEGER,
                             lPeriod: LONG,


### PR DESCRIPTION
Small fix for numeric literal suffixes and add added a compiler warning annotation for non camelcase types.
